### PR TITLE
Fix --with-xunit and python 3 file creation

### DIFF
--- a/lettuce/plugins/xunit_output.py
+++ b/lettuce/plugins/xunit_output.py
@@ -24,10 +24,10 @@ from lettuce.strings import utf8_string
 
 def wrt_output(filename, content):
     f = open(filename, "w")
-    if isinstance(content, unicode):
+    if isinstance(content, str):
         content = content.encode('utf-8')
 
-    f.write(content)
+    f.write(content.decode('utf-8'))
     f.close()
 
 


### PR DESCRIPTION
# Description

This PR try to fix the creation of the lettucetests.xml (--with-xunit parameter) for python 3 environment.

# Issue

When in python 3 and you type this command :
`lettuce --with-xunit`
The file lettucetests.xml is created, but is empty. In the console part you should have :
```
    if isinstance(content, unicode):
NameError: name 'unicode' is not defined
```